### PR TITLE
Add Docker Compose Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,7 @@ modules/__pycache__/
 *.bkp
 
 # Current config folder
-#config/current_config/*
+config/current_config/*
+
+# yaml files
+*.yaml

--- a/modules/docker.py
+++ b/modules/docker.py
@@ -342,12 +342,6 @@ def get_container_port(container_name):
     return container_port
 
 def get_composefile_path_content() -> Tuple[str, dict]:
-    # Obtain the Container name from the compose file. If there
-    # is no name provided, error out for now. 
-    #
-    # We currently need to provide a static name for the container as otherwhise, docker compose
-    # would dynamically generate a name. The name is needed to obtain the IP - Address of the container
-    # and to add a firewall rule. 
     compose_file_path = str(input("Pfad zur Docker Compose File: "))
     compose_file_content = ''
 
@@ -355,10 +349,10 @@ def get_composefile_path_content() -> Tuple[str, dict]:
         compose_file_content = open_docker_composefile(compose_file_path)
     except ValueError:
         print('Der angegebene Pfad scheint nicht zu existieren')
-        return
+        return None, None
     except Exception as ex:
         print(f'Die Docker Compose File konnte nicht geöffnet werden. {ex}')
-        return
+        return None, None
 
     return compose_file_path, compose_file_content
 

--- a/modules/docker.py
+++ b/modules/docker.py
@@ -1,9 +1,13 @@
+from multiprocessing.sharedctypes import Value
 import os
 import sys
 import json
+from typing import List
 import uuid
 from .pyufw import pyufw
 from . import firewall as fw
+
+from yaml import load, Loader
 
 # Create Image
 def create_image():
@@ -82,6 +86,41 @@ def create_container():
     # Add firewall rule for container and add port-mapping to json file
     add_container_port_mapping(port=str(port_list[0]),container_name=str(container_name))
     add_container_firewall_rule(port=str(port_list[0]),container_name=str(container_name))
+
+# Adds a containers from a given docker compose file.
+def add_docker_compose_file():
+    # Obtain the Container name from the compose file. If there
+    # is no name provided, error out for now. 
+    #
+    # We currently need to provide a static name for the container as otherwhise, docker compose
+    # would dynamically generate a name. The name is needed to obtain the IP - Address of the container
+    # and to add a firewall rule. 
+    compose_file_path = str(input("Pfad zur Docker Compose File: "))
+    compose_file_content = ''
+
+    try:
+        compose_file_content = open_docker_composefile(compose_file_path)
+    except ValueError:
+        print('Der angegebene Pfad scheint nicht zu existieren')
+        return
+    except Exception as ex:
+        print(f'Die Docker Compose File konnte nicht geöffnet werden. {ex}')
+        return
+
+    # Start the containers using docker compose
+    compose_command = f'docker-compose -f {compose_file_path} up -d'
+    fw.ufw_allow_outgoing()
+    os.system(compose_command)
+    fw.ufw_deny_outgoing()
+
+    # Parse out the container names from the compose file and add the port mappings and firewall rules
+    container_names_ports = get_container_names_ports_from_composefile(compose_file_content)
+    print(container_names_ports)
+
+    for name, ports in container_names_ports.items():
+        for port in ports:
+            add_container_port_mapping(port, name)
+            add_container_firewall_rule(port, name)
 
 
 # Start given container
@@ -294,3 +333,36 @@ def get_container_port(container_name):
             container_port = get_key.get('port')
     
     return container_port
+
+def open_docker_composefile(path: str) -> dict:
+     # Error out if the path does not exists
+    if not os.path.exists(path):
+        print(path)
+        raise ValueError()
+
+    docker_compose_content = ''
+    with open(path) as file:
+        # Note: Currently, I do not want to do the hassle to recompile this module with the libyaml C Bindings just
+        # to load the docker-compose file. If we experience any performance issues here, we should consider it. 
+        docker_compose_content = load(file, Loader)
+
+    return docker_compose_content
+
+def get_container_names_ports_from_composefile(composefile: dict) -> List[dict]:
+    """
+    Returns a dictionary which maps the container name to a list of all published
+    ports of this container, as specified in the passed docker composefile. 
+    """
+    container_port_dict = {}
+    for service in composefile['services'].values():
+        try: 
+            container_name = service['container_name']
+        except KeyError:
+            print(f'Für Service {service} wurde kein Container Name gefunden.' +
+                ' Dieser Service wird somit in der Firewall Konfiguration ignoriert und ist von aussen nicht erreichbar.')
+            continue
+    
+        container_ports = tuple(port.split(':')[0] for port in service.get('ports', []))
+        container_port_dict[container_name] = container_ports
+
+    return container_port_dict

--- a/modules/docker.py
+++ b/modules/docker.py
@@ -218,13 +218,28 @@ def start_container_from_compose_file():
 
     # Parse out the container names from the compose file and add the port mappings and firewall rules
     container_names_ports = get_container_names_ports_from_composefile(compose_file_content)
-    print(container_names_ports)
 
     for name, ports in container_names_ports.items():
         for port in ports:
             add_container_port_mapping(port, name)
             add_container_firewall_rule(port, name)
 
+def stop_container_from_compose_file():
+    compose_file_path, compose_file_content = get_composefile_path_content()
+
+    if not compose_file_path:
+        return
+
+    # Stop the container using docker compose
+    compose_command = f'docker-compose -f {compose_file_path} down'
+    os.system(compose_command)
+
+    # Parse out the container names from the compose file and add the port mappings and firewall rules
+    container_names_ports = get_container_names_ports_from_composefile(compose_file_content)
+
+    for name in container_names_ports.keys():
+        remove_container_port_mapping(name)
+        remove_container_firewall_rule(name)
 
 # Save container port-mapping to a json file
 def add_container_port_mapping(port='', container_name=''):

--- a/modules/docker.py
+++ b/modules/docker.py
@@ -87,42 +87,6 @@ def create_container():
     add_container_port_mapping(port=str(port_list[0]),container_name=str(container_name))
     add_container_firewall_rule(port=str(port_list[0]),container_name=str(container_name))
 
-# Adds a containers from a given docker compose file.
-def add_docker_compose_file():
-    # Obtain the Container name from the compose file. If there
-    # is no name provided, error out for now. 
-    #
-    # We currently need to provide a static name for the container as otherwhise, docker compose
-    # would dynamically generate a name. The name is needed to obtain the IP - Address of the container
-    # and to add a firewall rule. 
-    compose_file_path = str(input("Pfad zur Docker Compose File: "))
-    compose_file_content = ''
-
-    try:
-        compose_file_content = open_docker_composefile(compose_file_path)
-    except ValueError:
-        print('Der angegebene Pfad scheint nicht zu existieren')
-        return
-    except Exception as ex:
-        print(f'Die Docker Compose File konnte nicht geöffnet werden. {ex}')
-        return
-
-    # Start the containers using docker compose
-    compose_command = f'docker-compose -f {compose_file_path} up -d'
-    fw.ufw_allow_outgoing()
-    os.system(compose_command)
-    fw.ufw_deny_outgoing()
-
-    # Parse out the container names from the compose file and add the port mappings and firewall rules
-    container_names_ports = get_container_names_ports_from_composefile(compose_file_content)
-    print(container_names_ports)
-
-    for name, ports in container_names_ports.items():
-        for port in ports:
-            add_container_port_mapping(port, name)
-            add_container_firewall_rule(port, name)
-
-
 # Start given container
 def start_container(container_name=''):
     if container_name == '':
@@ -238,6 +202,41 @@ def delete_volume(volume_name=''):
         os.system('sudo docker volume rm --force ' + str(volume_name))
         # Print 2 empty Lines for better reading
         print('\n\n')
+
+# Adds a containers from a given docker compose file.
+def start_container_from_compose_file():
+    # Obtain the Container name from the compose file. If there
+    # is no name provided, error out for now. 
+    #
+    # We currently need to provide a static name for the container as otherwhise, docker compose
+    # would dynamically generate a name. The name is needed to obtain the IP - Address of the container
+    # and to add a firewall rule. 
+    compose_file_path = str(input("Pfad zur Docker Compose File: "))
+    compose_file_content = ''
+
+    try:
+        compose_file_content = open_docker_composefile(compose_file_path)
+    except ValueError:
+        print('Der angegebene Pfad scheint nicht zu existieren')
+        return
+    except Exception as ex:
+        print(f'Die Docker Compose File konnte nicht geöffnet werden. {ex}')
+        return
+
+    # Start the containers using docker compose
+    compose_command = f'docker-compose -f {compose_file_path} up -d'
+    fw.ufw_allow_outgoing()
+    os.system(compose_command)
+    fw.ufw_deny_outgoing()
+
+    # Parse out the container names from the compose file and add the port mappings and firewall rules
+    container_names_ports = get_container_names_ports_from_composefile(compose_file_content)
+    print(container_names_ports)
+
+    for name, ports in container_names_ports.items():
+        for port in ports:
+            add_container_port_mapping(port, name)
+            add_container_firewall_rule(port, name)
 
 
 # Save container port-mapping to a json file

--- a/modules/docker.py
+++ b/modules/docker.py
@@ -2,7 +2,7 @@ from multiprocessing.sharedctypes import Value
 import os
 import sys
 import json
-from typing import List
+from typing import List, Tuple
 import uuid
 from .pyufw import pyufw
 from . import firewall as fw
@@ -205,22 +205,9 @@ def delete_volume(volume_name=''):
 
 # Adds a containers from a given docker compose file.
 def start_container_from_compose_file():
-    # Obtain the Container name from the compose file. If there
-    # is no name provided, error out for now. 
-    #
-    # We currently need to provide a static name for the container as otherwhise, docker compose
-    # would dynamically generate a name. The name is needed to obtain the IP - Address of the container
-    # and to add a firewall rule. 
-    compose_file_path = str(input("Pfad zur Docker Compose File: "))
-    compose_file_content = ''
+    compose_file_path, compose_file_content = get_composefile_path_content()
 
-    try:
-        compose_file_content = open_docker_composefile(compose_file_path)
-    except ValueError:
-        print('Der angegebene Pfad scheint nicht zu existieren')
-        return
-    except Exception as ex:
-        print(f'Die Docker Compose File konnte nicht geöffnet werden. {ex}')
+    if not compose_file_path:
         return
 
     # Start the containers using docker compose
@@ -332,6 +319,27 @@ def get_container_port(container_name):
             container_port = get_key.get('port')
     
     return container_port
+
+def get_composefile_path_content() -> Tuple[str, dict]:
+    # Obtain the Container name from the compose file. If there
+    # is no name provided, error out for now. 
+    #
+    # We currently need to provide a static name for the container as otherwhise, docker compose
+    # would dynamically generate a name. The name is needed to obtain the IP - Address of the container
+    # and to add a firewall rule. 
+    compose_file_path = str(input("Pfad zur Docker Compose File: "))
+    compose_file_content = ''
+
+    try:
+        compose_file_content = open_docker_composefile(compose_file_path)
+    except ValueError:
+        print('Der angegebene Pfad scheint nicht zu existieren')
+        return
+    except Exception as ex:
+        print(f'Die Docker Compose File konnte nicht geöffnet werden. {ex}')
+        return
+
+    return compose_file_path, compose_file_content
 
 def open_docker_composefile(path: str) -> dict:
      # Error out if the path does not exists

--- a/modules/menus.py
+++ b/modules/menus.py
@@ -105,11 +105,12 @@ def container_submenu():
           '8.\t Container löschen \n' +
           '9.\t Image löschen \n' +
           '10.\t Volume löschen \n' +
-          '11. \t Docker Compose File hinzufügen' +
-          '-- Please enter a number (0-10) --')
+          '11. \t Container von Compose File starten' +
+          '12. \t Container von Compose File stoppen'
+          '-- Please enter a number (0-12) --')
 
     # Get a Number from the user in given range
-    case_number = hf.get_int(0,12)
+    case_number = hf.get_int(0,13)
     
     match case_number:
         case 0:
@@ -145,7 +146,7 @@ def container_submenu():
             doc.delete_volume()
             container_submenu()
         case 11:
-            doc.add_docker_compose_file()
+            doc.start_container_from_compose_file()
             container_submenu()
 
 

--- a/modules/menus.py
+++ b/modules/menus.py
@@ -105,10 +105,11 @@ def container_submenu():
           '8.\t Container löschen \n' +
           '9.\t Image löschen \n' +
           '10.\t Volume löschen \n' +
+          '11. \t Docker Compose File hinzufügen' +
           '-- Please enter a number (0-10) --')
 
     # Get a Number from the user in given range
-    case_number = hf.get_int(0,11)
+    case_number = hf.get_int(0,12)
     
     match case_number:
         case 0:
@@ -142,6 +143,9 @@ def container_submenu():
             container_submenu()
         case 10:
             doc.delete_volume()
+            container_submenu()
+        case 11:
+            doc.add_docker_compose_file()
             container_submenu()
 
 

--- a/modules/menus.py
+++ b/modules/menus.py
@@ -105,8 +105,8 @@ def container_submenu():
           '8.\t Container löschen \n' +
           '9.\t Image löschen \n' +
           '10.\t Volume löschen \n' +
-          '11. \t Container von Compose File starten' +
-          '12. \t Container von Compose File stoppen'
+          '11. \t Container von Compose File starten\n' +
+          '12. \t Container von Compose File stoppen\n'
           '-- Please enter a number (0-12) --')
 
     # Get a Number from the user in given range
@@ -147,6 +147,9 @@ def container_submenu():
             container_submenu()
         case 11:
             doc.start_container_from_compose_file()
+            container_submenu()
+        case 12:
+            doc.stop_container_from_compose_file()
             container_submenu()
 
 


### PR DESCRIPTION
Dieser PR fügt einen Support für das Handling von Docker - Compose files hinzu. Hierbei gibt es im Docker - Untermenü nun zwei neue Punkte: 
* Container von Compose File starten
* Container von Compose File stoppen 

Danach kann der Nutzer jeweils einen Pfad zu einer Compose - Datei angeben. Die Firewall Regeln werden dann, wie bei den anderen Containern auch, entsprechend aktualisiert. 

Bitte schau hier einmal drüber. Falls du noch irgendwelche Fragen dazu hast, sag einfach bescheid. 